### PR TITLE
[OP-1123] Bump deprecated GHAs in ci.yml and cd.yml files

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,8 +2,7 @@ name: Deploy styleguide to S3
 on:
   push:
     branches:
-#      - master
-      - OP-1123-GHA-bump-deprecated-gha
+      - master
 
 jobs:
   build-and-deploy:
@@ -42,6 +41,6 @@ jobs:
       - name: Build and export Storybook
         run: pnpm build-storybook
 
-      # - name: Deploy to S3
-      #   run:
-      #     aws s3 sync ./storybook-static/ s3://styleguide.landingi.com --delete
+      - name: Deploy to S3
+        run:
+          aws s3 sync ./storybook-static/ s3://styleguide.landingi.com --delete

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,8 @@ name: Deploy styleguide to S3
 on:
   push:
     branches:
-      - master
+#      - master
+      - OP-1123-GHA-bump-deprecated-gha
 
 jobs:
   build-and-deploy:
@@ -12,7 +13,7 @@ jobs:
       contents: read
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::084824767965:role/gha-ui-kit
           role-duration-seconds: 3600
@@ -22,16 +23,16 @@ jobs:
       - run: aws sts get-caller-identity
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Nodejs
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
           cache-dependency-path: pnpm-lock.yaml
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2.0.1
+        uses: pnpm/action-setup@v2.4.0
         with:
           version: 8.6.12
 
@@ -41,6 +42,6 @@ jobs:
       - name: Build and export Storybook
         run: pnpm build-storybook
 
-      - name: Deploy to S3
-        run:
-          aws s3 sync ./storybook-static/ s3://styleguide.landingi.com --delete
+      # - name: Deploy to S3
+      #   run:
+      #     aws s3 sync ./storybook-static/ s3://styleguide.landingi.com --delete

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,4 @@
-# on: 'pull_request'
-on:
-  push:
-    branches:
-      - OP-1123-GHA-bump-deprecated-gha
+on: 'pull_request'
 
 jobs:
   CI:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,19 +1,23 @@
-on: 'pull_request'
+# on: 'pull_request'
+on:
+  push:
+    branches:
+      - OP-1123-GHA-bump-deprecated-gha
 
 jobs:
   CI:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup Nodejs
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
           cache-dependency-path: pnpm-lock.yaml
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2.0.1
+        uses: pnpm/action-setup@v2.4.0
         with:
           version: 8.6.12
 


### PR DESCRIPTION
Bump deprecated GHAs in ci.yml and cd.yml files, what was changed 

**ci.yml**
  1. actions/setup-node@v2 -> v4
  2. pnpm/action-setup@v2.0.1 -> 2.4.0

**cd.yml**
  1. aws-actions/configure-aws-credentials@v2 -> v4
  2. actions/checkout@v3 -> v4
  3. actions/setup-node@v2 -> v4
  4. pnpm/action-setup@v2.0.1 -> 2.4.0